### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,47 +6,47 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-EnergyBoard				KEYWORD1
+EnergyBoard	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Voltage_RMS				KEYWORD2
-Voltage_RMS_Average		KEYWORD2
+Voltage_RMS	KEYWORD2
+Voltage_RMS_Average	KEYWORD2
 Voltage_Instantaneous	KEYWORD2
-Voltage_Fundamental		KEYWORD2
-Voltage_Harmonic		KEYWORD2
+Voltage_Fundamental	KEYWORD2
+Voltage_Harmonic	KEYWORD2
 Voltage_RMS_Alarm_Min	KEYWORD2
 Voltage_RMS_Alarm_Max	KEYWORD2
-Current_RMS				KEYWORD2
-Current_RMS_Average		KEYWORD2
-Current_Peak			KEYWORD2
+Current_RMS	KEYWORD2
+Current_RMS_Average	KEYWORD2
+Current_Peak	KEYWORD2
 Current_Instantaneous	KEYWORD2
-Current_Fundamental		KEYWORD2
-Current_Harmonic		KEYWORD2
+Current_Fundamental	KEYWORD2
+Current_Harmonic	KEYWORD2
 Current_RMS_Alarm_Max	KEYWORD2
-Power_Active			KEYWORD2
+Power_Active	KEYWORD2
 Power_Active_Average	KEYWORD2
-Power_Reactive			KEYWORD2
+Power_Reactive	KEYWORD2
 Power_Reactive_Average	KEYWORD2
-Power_Apparent			KEYWORD2
+Power_Apparent	KEYWORD2
 Power_Apparent_Average	KEYWORD2
-Power_Fundamental		KEYWORD2
-Power_Harmonic			KEYWORD2
+Power_Fundamental	KEYWORD2
+Power_Harmonic	KEYWORD2
 Power_Fundamental_VA	KEYWORD2
-Power_Factor			KEYWORD2
+Power_Factor	KEYWORD2
 Power_Factor_Average	KEYWORD2
-Frequency				KEYWORD2
-IC_Temperature			KEYWORD2
+Frequency	KEYWORD2
+IC_Temperature	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-BoudRate				LITERAL1
-Voltage_Gain			LITERAL1
-Current_Gain			LITERAL1
-Power_Gain				LITERAL1
-Power_Factor_Gain		LITERAL1
-Frequency_Gain			LITERAL1
+BoudRate	LITERAL1
+Voltage_Gain	LITERAL1
+Current_Gain	LITERAL1
+Power_Gain	LITERAL1
+Power_Factor_Gain	LITERAL1
+Frequency_Gain	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords